### PR TITLE
Fix Istio Virtual Service gateway source

### DIFF
--- a/source/store.go
+++ b/source/store.go
@@ -104,7 +104,7 @@ func (p *SingletonClientGenerator) IstioGatewayClient() (istiomodel.ConfigStore,
 // IstioVirtualServiceClient generates an istio client if it was not created before
 func (p *SingletonClientGenerator) IstioVirtualServiceClient() (istiomodel.ConfigStore, error) {
 	var err error
-	p.istioGatewayOnce.Do(func() {
+	p.istioVirtualServiceOnce.Do(func() {
 		p.istioVirtualServiceClient, err = NewIstioVirtualServiceClient(p.KubeConfig)
 	})
 	return p.istioVirtualServiceClient, err


### PR DESCRIPTION
Currently, you must reference the gateway with the full namespace. A fallback to the virtual service one can be easily implemented.